### PR TITLE
Set up CODEOWNERS and settings.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owners for everything
+* @suzubara @abbyoung
+
+# Github settings
+.github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,57 @@
+# See https://developer.github.com/v3/repos/#edit for all available settings.
+repository:
+  name: ussf-portal-prototype
+  description: Prototype of the USSF portal for testing purposes
+  homepage: https://prototype.ussforbit.us/
+  private: false
+  has_issues: true
+  has_projects: true
+  has_wiki: true
+  default_branch: main
+  allow_squash_merge: true
+  # This will allow merge commits on branches, but only squash merges allowed on main (below)
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+# Labels: define labels for Issues and Pull Requests
+labels:
+  - name: bug
+    color: CC0000
+  - name: feature
+    color: 336699
+  - name: first-timers-only
+    # include the old name to rename and existing label
+    oldname: Help Wanted
+
+branches:
+  - name: main
+    # Branch Protection settings. Set to null to disable
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: []
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: true
+      # Commits pushed to matching branches must have verified signatures. Set to false to disable.
+      required_signatures: true
+      required_linear_history: true
+      allow_force_pushes: false
+      allow_deletions: false
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: []
+        users: []
+        teams: []


### PR DESCRIPTION
## Description 

This PR adds a CODEOWNERS file and repo/branch protection settings in yaml:
* Auto-delete head branches after merging
* `main` branch protection:
  * Require linear history (default to squash commits)
  * Dismiss stale reviews if a PR is updated
  * Require branches to be up to date before merging?
  * Require a review from code owners (code owners being all of eng + Noah)
  * Require signed commits (requires setting up your CAC or yubikey)


Fixes #10 

## Review Notes

The settings changes will only be synced when they are made to the default branch (`main`) so this PR needs to be merged to test. That's what the prototype is for!

I left the example label in this file to verify it works as expected first. If this goes well then I'll update to add all of our labels (https://github.com/USSF-ORBIT/ussf-portal-prototype/issues/12)