### PR TITLE
Add Node CI Github workflow

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,38 @@
+name: Node CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.15.0'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # The yarn cache is not node_modules
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --prefer-offline
+
+      - name: Lint code
+        run: yarn lint

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Lint code
         run: yarn lint
+
+      - name: Run Jest tests
+        run: yarn test --coverage

--- a/components/Logo/Logo.test.tsx
+++ b/components/Logo/Logo.test.tsx
@@ -18,6 +18,6 @@ describe('Logo component', () => {
     render(<Logo size={250} />)
 
     const image = screen.getByRole('img')
-    expect(image).toHaveAttribute('alt', 'Space Force')
+    expect(image).not.toHaveAttribute('alt', 'Space Force')
   })
 })

--- a/components/Logo/Logo.test.tsx
+++ b/components/Logo/Logo.test.tsx
@@ -18,6 +18,6 @@ describe('Logo component', () => {
     render(<Logo size={250} />)
 
     const image = screen.getByRole('img')
-    expect(image).not.toHaveAttribute('alt', 'Space Force')
+    expect(image).toHaveAttribute('alt', 'Space Force')
   })
 })

--- a/components/Logo/Logo.test.tsx
+++ b/components/Logo/Logo.test.tsx
@@ -6,9 +6,18 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import Logo from './Logo'
 
-test('Logo is rendered', () => {
-  render(<Logo size={250} />)
+describe('Logo component', () => {
+  it('renders without a size prop', () => {
+    render(<Logo />)
 
-  const image = screen.getByRole('img')
-  expect(image).toHaveAttribute('alt', 'Space Force')
+    const image = screen.getByRole('img')
+    expect(image).toHaveAttribute('alt', 'Space Force')
+  })
+
+  it('renders with a size prop', () => {
+    render(<Logo size={250} />)
+
+    const image = screen.getByRole('img')
+    expect(image).toHaveAttribute('alt', 'Space Force')
+  })
 })

--- a/components/Logo/Logo.tsx
+++ b/components/Logo/Logo.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 
 export type LogoProps = {
-  size: number
+  size?: number
 }
 
 const Logo = ({ size = 250 }: LogoProps) => {

--- a/components/Logo/Logo.tsx
+++ b/components/Logo/Logo.tsx
@@ -6,6 +6,8 @@ export type LogoProps = {
 }
 
 const Logo = ({ size = 250 }: LogoProps) => {
+  var testVar = 'this is never used!'
+
   return (
     <div>
       <Image

--- a/components/Logo/Logo.tsx
+++ b/components/Logo/Logo.tsx
@@ -6,8 +6,6 @@ export type LogoProps = {
 }
 
 const Logo = ({ size = 250 }: LogoProps) => {
-  var testVar = 'this is never used!'
-
   return (
     <div>
       <Image

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,12 @@ module.exports = {
     '\\.(scss|sass|css|png)$': 'identity-obj-proxy',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  coverageThreshold: {
+    global: {
+      statements: 95,
+      branches: 95,
+      functions: 95,
+      lines: 95,
+    },
+  },
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "portal-prototype",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "14.15.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Description 

Sets up Github Actions CI with some baseline Node checks:
- linter
- unit tests (Jest) with minimum coverage thresholds

Fixes #14 

## Review Notes

I made the following commits to this branch for testing:

Commit https://github.com/USSF-ORBIT/ussf-portal-prototype/pull/16/commits/2a40a37d8e01a61d51b6042cd37e6df0b6136da9 includes a failing test and an ESLint error, and [failed the workflow](https://github.com/USSF-ORBIT/ussf-portal-prototype/runs/2956756866?check_suite_focus=true).

Commit https://github.com/USSF-ORBIT/ussf-portal-prototype/pull/16/commits/42125b523a9d360d135ca760b966337c101828f7 fixes the ESLint error but the [test still fails](https://github.com/USSF-ORBIT/ussf-portal-prototype/runs/2956770264?check_suite_focus=true).