### PR TITLE
chore: Add uswds scss to Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
-import '@trussworks/react-uswds/lib/uswds.css'
-import '@trussworks/react-uswds/lib/index.css'
+import '../styles/storybook.scss'
 import * as NextImage from 'next/image'
 
 // Storybook and next/image component do not play nice together

--- a/styles/settings.scss
+++ b/styles/settings.scss
@@ -1,5 +1,5 @@
 // your-project/settings.scss
-$theme-show-notifications: 'false';
+$theme-show-notifications: false;
 /* GENERAL */
 $theme-image-path: '/img';
 

--- a/styles/storybook.scss
+++ b/styles/storybook.scss
@@ -1,0 +1,21 @@
+/* Storybook requires different paths for variables,
+which requires a custom import order to replace those settings */
+@import '@trussworks/react-uswds/lib/index.css';
+@import '~uswds/dist/scss/theme/uswds-theme-general';
+@import '~uswds/dist/scss/theme/uswds-theme-typography';
+@import '~uswds/dist/scss/theme/uswds-theme-spacing';
+@import '~uswds/dist/scss/theme/uswds-theme-color';
+@import '~uswds/dist/scss/theme/uswds-theme-utilities';
+
+$theme-show-notifications: false;
+/* GENERAL */
+$theme-image-path: '~uswds/dist/img';
+
+/* TYPOGRAPHY */
+$theme-font-path: '~uswds/dist/fonts';
+
+/* COMPONENTS */
+$theme-hero-image: '~uswds/dist/img/hero.png';
+
+@import '~uswds/src/stylesheets/packages/_required.scss';
+@import '~uswds/dist/scss/uswds.scss';


### PR DESCRIPTION
## Description 
Fixing missing import of uswds dependencies in Storybook.

* Creates `styles/storybook.scss` to manage uswds dependencies and storybook-specific paths for variables
* Imports file in `preview.js`
* Fixes string -> bool to turn notifications off

Fixes #27 



