### PR TITLE
ci: tweaking codeowners to see if we can appease renovatebot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything
-* @suzubara @abbyoung
+pages/ @suzubara @abbyoung
 
 # Github settings
 .github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth


### PR DESCRIPTION
## Description 

Renovatebot won't auto-approve with CODEOWNERS. This is an attempt to appease renovatebot.

Fixes # NT

## Review Notes
