### PR TITLE
ci: removing codeowners to see if renovatebot will work

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Default owners for everything
-pages/ @suzubara @abbyoung
-
-# Github settings
-.github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth


### PR DESCRIPTION
## Description 

I'm at a bit of a loss. Renovatebot _seems_ to be working. I have this [plugin](https://github.com/organizations/USSF-ORBIT/settings/installations/18956475) which should approve PR's that pass...but it's not working. And the only thing I can think of is the existence of `CODEOWNERS` is messing with it. So this is to just test. 