### PR TITLE
ci: adding codeowners back to see if Renovatebot will work

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owners for everything
+pages/ @suzubara @abbyoung
+
+# Github settings
+.github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth


### PR DESCRIPTION
## Description 

Seems a revert in Github is not a signed commit, so it couldn't be merged. This is me doing it again. 
