### PR TITLE
ci: single pr for minor and patch updates from renovatebot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Default owners for everything
-pages/ @suzubara @abbyoung
-
-# Github settings
-.github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,18 @@
       {
         "matchPackageNames": ["uswds"],
         "enabled": false
+      },
+      {
+        "automerge": true,
+        "description": "Group minor and patch updates into a single PR",
+        "groupName": "dependencies",
+        "managers": [
+         "npm"
+        ],
+        "matchUpdateTypes": [
+          "minor",
+          "patch"
+        ]
       }
 
   ],


### PR DESCRIPTION
## Description 

Following the pattern from another repo at Truss that uses Renovate bot, this should group minor and patch updates into a single PR so we don't have so many outstanding PR's. This also removes `CODEOWNERS` to test if this will allow `renovate-approve` bot to approve PR's in it's absence.
